### PR TITLE
04 api/articles/article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -58,8 +58,15 @@ describe('GET /api/articles/:article_id', () => {
         .get('/api/articles/1')
         .expect(200)
         .then(({body:article}) => {
-            const expectedResult = endpointsJsonFile["GET /api/articles/:article_id"].exampleResponse.article
-            expect(article).toMatchObject(expectedResult)
+            expect(article).toMatchObject({
+              article_id : 1,
+              author : "butter_bridge",
+              title : "Living in the shadow of a great man",
+              body : "I find this existence challenging",
+              created_at : "2020-07-09T20:11:00.000Z",
+              votes : 100,
+              article_img_url: "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+            })
         })
     });
     it("404: responds with 'Not Found' when given valid but non-existing id", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -75,7 +75,7 @@ describe('GET /api/articles/:article_id', () => {
       .expect(404)
       .then(({body}) =>{
         const errorMsg = body.msg
-        expect(errorMsg).toBe("Not Found")
+        expect(errorMsg).toBe("Resource Not Found")
       })
     })
     it("400: responds with 'Bad Request' when failing schema validation", () => {

--- a/api/models/app.api.articles.models.js
+++ b/api/models/app.api.articles.models.js
@@ -12,7 +12,7 @@ exports.fetchArticleById = (article_id) => {
         const article = data.rows[0]
 
         if(!article) {
-            return Promise.reject({status: 404, msg: 'Not Found'})
+            return Promise.reject({status: 404, msg: 'Resource Not Found'})
         }
         return article
     })


### PR DESCRIPTION
Hi NC team

I made some changes to the GET /api/articles/:article_id endpoint, in line with your feedback:
- made the test expectations explicit for the 200 route 
- changed the custom 404 error message to be unique to the error case - now reads 'Resource Not Found'